### PR TITLE
Disable beta and betaagent bots with redirect message

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -382,8 +382,27 @@ class SlackMCPApp {
     }
   }
 
+  // Bots that have been disabled. Messages to these bots get a redirect reply instead of processing.
+  private static readonly DISABLED_BOTS = new Set(['beta', 'betaagent']);
+  private static readonly DISABLED_BOT_MESSAGE =
+    'This agent has been turned off. Please go to <https://www.chat.cauldron.sefaria.org/|chat.cauldron.sefaria.org> to keep using the agent. If you don\'t see the agent there, please ask someone from the dev team for help.';
+
   private async processWithWorkflow(event: SlackMessageEvent, bot: BotConfig): Promise<void> {
     try {
+      // Short-circuit disabled bots with a redirect message
+      if (SlackMCPApp.DISABLED_BOTS.has(bot.name)) {
+        console.log(`[WORKFLOW] Bot "${bot.name}" is disabled, sending redirect message`);
+        const { WebClient } = await import('@slack/web-api');
+        const client = new WebClient(bot.slackToken);
+        await client.chat.postMessage({
+          channel: event.channel,
+          thread_ts: event.thread_ts || event.ts,
+          text: SlackMCPApp.DISABLED_BOT_MESSAGE,
+          mrkdwn: true
+        });
+        return;
+      }
+
       console.log(`🔄 [WORKFLOW] Starting LangGraph workflow for bot "${bot.name}"...`);
       console.log('🔄 [WORKFLOW] Event summary:', {
         user: event.user,


### PR DESCRIPTION
## Summary
- Disables `beta` and `betaagent` Slack bots by short-circuiting their workflow processing
- When messaged, these bots now reply with a redirect to https://www.chat.cauldron.sefaria.org/ instead of running the full LangGraph workflow
- No Claude API calls, MCP connections, or Braintrust tracing for disabled bots

## Test plan
- [ ] Message the beta bot in Slack and verify it replies with the redirect message
- [ ] Message the betaagent bot and verify the same
- [ ] Verify other bots (bina, binah) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)