### PR TITLE
Fix infinite loop when disabled bot replies trigger new events

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -390,7 +390,8 @@ class SlackMCPApp {
   private async processWithWorkflow(event: SlackMessageEvent, bot: BotConfig): Promise<void> {
     try {
       // Short-circuit disabled bots with a redirect message
-      if (SlackMCPApp.DISABLED_BOTS.has(bot.name)) {
+      // Skip bot messages to avoid infinite loop (bot's own replies trigger new events)
+      if (SlackMCPApp.DISABLED_BOTS.has(bot.name) && !event.bot_id && !event.subtype) {
         console.log(`[WORKFLOW] Bot "${bot.name}" is disabled, sending redirect message`);
         const { WebClient } = await import('@slack/web-api');
         const client = new WebClient(bot.slackToken);


### PR DESCRIPTION
## Summary
- Adds `bot_id` and `subtype` check to the disabled bot handler to prevent the bot's own reply from re-triggering the disabled message in a loop

## Test plan
- [ ] Message a disabled bot — should get exactly one redirect reply
- [ ] Verify no infinite loop of repeated messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)